### PR TITLE
Change casing of build folders to lowercase

### DIFF
--- a/Source/Webpack/WebpackConfiguration.ts
+++ b/Source/Webpack/WebpackConfiguration.ts
@@ -40,9 +40,9 @@ export class WebpackConfiguration {
         'sass-loader'
     ];
 
-    private _featuresDir = process.env.DOLITTLE_FEATURES_DIR || './Features';
+    private _featuresDir = process.env.DOLITTLE_FEATURES_DIR || './features';
     private _componentDir =
-        process.env.DOLITTLE_COMPONENT_DIR || './Components';
+        process.env.DOLITTLE_COMPONENT_DIR || './components';
 
     private _outDir =
         process.env.DOLITTLE_WEBPACK_OUT ||
@@ -109,7 +109,7 @@ export class WebpackConfiguration {
                 'node_modules'
             ],
             alias: {
-                DolittleStyles: path.resolve(this._rootDir, 'Styles')
+                DolittleStyles: path.resolve(this._rootDir, 'styles')
             }
         };
         return resolve;


### PR DESCRIPTION
casing keep giving us trouble so standardize for lowercase for the frontend.

Also standardizes folders to lowercase in conjunction with https://github.com/dolittle-boilerplates/Interaction.Web.TS.Aurelia/pull/4

We have to update these 2 pulls simultaneously (unless we add cases for also using old-style uppercase folder names) and we also have to update the `package.json` with the updated @dolittle/typescript.webpack

Also https://github.com/dolittle-tools/TypeScript.Webpack.Aurelia is depending on this package to that should probably also get updated.